### PR TITLE
fix: remove matrix.version from lint and format steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup Zig
       uses: mlugg/setup-zig@v2
       with:
-        version: ${{ matrix.zig-version }}
+        version: 0.14.1
 
     - name: Check formatting
       run: zig fmt --check src/
@@ -51,7 +51,7 @@ jobs:
     - name: Setup Zig
       uses: mlugg/setup-zig@v2
       with:
-        version: ${{ matrix.zig-version }}
+        version: 0.14.1
 
     - name: Zig check
       run: zig build --summary all


### PR DESCRIPTION
The `matrix.version` var is only specified on the test step for CI. Hard code the version for the other steps for now.