### PR TITLE
build: expose module for external consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,57 @@ You need:
 
 ### Installation
 
-#### Using Zig Package Manager (Recommended)
+#### Method 1: Using Git Submodule (Recommended for now)
 
-Add sentry-zig to your project using the Zig package manager:
+Since this is an experimental project, the easiest way to integrate it is as a git submodule:
 
 ```bash
-# Add the dependency (replace with actual URL when published)
-zig fetch --save https://github.com/getsentry/sentry-zig/archive/refs/heads/main.tar.gz
+# Add as submodule in your project
+git submodule add https://github.com/getsentry/sentry-zig.git deps/sentry-zig
+git submodule update --init --recursive
 ```
 
 Then in your `build.zig`, add the sentry-zig dependency:
+
+```zig
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "my-app",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Add sentry-zig as a dependency
+    const sentry_zig_dep = b.addStaticLibrary(.{
+        .name = "sentry_zig",
+        .root_source_file = b.path("deps/sentry-zig/src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    
+    exe.linkLibrary(sentry_zig_dep);
+    exe.root_module.addImport("sentry_zig", sentry_zig_dep.root_module);
+    
+    b.installArtifact(exe);
+}
+```
+
+#### Method 2: Using Zig Package Manager (Experimental)
+
+If you want to use the package manager, first ensure your project has a `build.zig.zon` file, then:
+
+```bash
+# Add the dependency 
+zig fetch --save https://github.com/getsentry/sentry-zig/archive/refs/heads/main.tar.gz
+```
+
+Then update your `build.zig`:
 
 ```zig
 const std = @import("std");

--- a/build.zig
+++ b/build.zig
@@ -56,6 +56,18 @@ pub fn build(b: *std.Build) void {
     // running `zig build`).
     b.installArtifact(lib);
 
+    // Export the main module for external consumption
+    // This allows other projects to import it via b.dependency().module()
+    const sentry_module = b.addModule("sentry_zig", .{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Add the same dependencies that the library has
+    sentry_module.addOptions("sentry_build", sentry_build_opts);
+    sentry_module.addImport("types", types);
+
     // Examples
     addExample(b, target, optimize, lib, "panic_handler", "Panic handler example");
     addExample(b, target, optimize, lib, "capture_message", "Run the captureMessage demo");


### PR DESCRIPTION
This way it can be used in other projects.