### PR TITLE
fix: properly cleanup scopes and resources

### DIFF
--- a/examples/capture_message.zig
+++ b/examples/capture_message.zig
@@ -22,7 +22,7 @@ pub fn main() !void {
         std.log.err("Failed to initialize Sentry client: {any}", .{err});
         return;
     };
-    defer client.deinit();
+    defer sentry.shutdown(allocator, client);
 
     std.log.info("Sentry captureMessage Demo", .{});
 

--- a/examples/capture_message.zig
+++ b/examples/capture_message.zig
@@ -18,7 +18,7 @@ pub fn main() !void {
         .send_default_pii = false,
     };
 
-    var client = sentry.init(allocator, dsn_string, options) catch |err| {
+    const client = sentry.init(allocator, dsn_string, options) catch |err| {
         std.log.err("Failed to initialize Sentry client: {any}", .{err});
         return;
     };

--- a/examples/panic_handler.zig
+++ b/examples/panic_handler.zig
@@ -18,7 +18,7 @@ pub fn main() !void {
         .send_default_pii = false,
     };
 
-    var client = sentry.init(allocator, dsn_string, options) catch |err| {
+    const client = sentry.init(allocator, dsn_string, options) catch |err| {
         std.log.err("Failed to initialize Sentry client: {any}", .{err});
         return;
     };

--- a/examples/panic_handler.zig
+++ b/examples/panic_handler.zig
@@ -22,7 +22,7 @@ pub fn main() !void {
         std.log.err("Failed to initialize Sentry client: {any}", .{err});
         return;
     };
-    defer client.deinit();
+    defer sentry.shutdown(allocator, client);
 
     std.log.info("Panic Handler Demo - triggering panic to test Sentry integration", .{});
 

--- a/src/client.zig
+++ b/src/client.zig
@@ -60,13 +60,6 @@ pub const SentryClient = struct {
             opts.dsn = try Dsn.parse(allocator, dsn_str);
         }
 
-        const client = SentryClient{
-            .options = opts,
-            .active = opts.dsn != null,
-            .allocator = allocator,
-            .transport = Transport.init(allocator, &opts),
-        };
-
         if (opts.debug) {
             std.log.debug("Initializing Sentry client", .{});
             if (opts.dsn) |parsed_dsn| {
@@ -81,6 +74,13 @@ pub const SentryClient = struct {
             }
             std.log.debug("Sample rate: {d}", .{opts.sample_rate});
         }
+
+        const client = SentryClient{
+            .options = opts,
+            .active = opts.dsn != null,
+            .allocator = allocator,
+            .transport = Transport.init(allocator, &opts),
+        };
 
         return client;
     }

--- a/src/client.zig
+++ b/src/client.zig
@@ -38,19 +38,24 @@ pub const SentryClient = struct {
         if (opts.dsn) |existing_dsn| {
             opts.dsn = try existing_dsn.clone(allocator);
         }
+        errdefer if (opts.dsn) |*d| d.deinit();
 
         if (opts.environment) |env| {
             opts.environment = try allocator.dupe(u8, env);
         }
+        errdefer if (opts.environment) |e| allocator.free(e);
+
         if (opts.release) |rel| {
             opts.release = try allocator.dupe(u8, rel);
         }
+        errdefer if (opts.release) |r| allocator.free(r);
 
         opts.allocator = allocator;
 
         if (dsn) |dsn_str| {
             if (opts.dsn) |*old_dsn| {
                 old_dsn.deinit();
+                opts.dsn = null; // Prevent double-free in errdefer
             }
             opts.dsn = try Dsn.parse(allocator, dsn_str);
         }

--- a/src/panic_handler.zig
+++ b/src/panic_handler.zig
@@ -26,7 +26,8 @@ pub fn panicHandler(msg: []const u8, first_trace_addr: ?usize) noreturn {
 }
 
 fn handlePanic(allocator: Allocator, msg: []const u8, first_trace_addr: ?usize) void {
-    const sentry_event = createSentryEvent(allocator, msg, first_trace_addr);
+    var sentry_event = createSentryEvent(allocator, msg, first_trace_addr);
+    defer sentry_event.deinit();
 
     _ = sentry.captureEvent(sentry_event) catch |err| {
         std.debug.print("cannot capture event, {}\n", .{err});
@@ -104,7 +105,8 @@ fn sendToSentry(event: Event) void {
 
 // Helper for tests: same as panic_handler but without process exit
 fn panic_handler_test_entry(allocator: Allocator, msg: []const u8, first_trace_addr: ?usize) void {
-    const sentry_event = createSentryEvent(allocator, msg, first_trace_addr);
+    var sentry_event = createSentryEvent(allocator, msg, first_trace_addr);
+    defer sentry_event.deinit();
     sendToSentry(sentry_event);
 }
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -17,6 +17,7 @@ pub const SentryClient = @import("client.zig").SentryClient;
 const scopes = @import("scope.zig");
 pub const ScopeType = scopes.ScopeType;
 pub const addBreadcrumb = scopes.addBreadcrumb;
+pub const deinitScopeManager = scopes.deinitScopeManager;
 
 pub const panicHandler = @import("panic_handler.zig").panicHandler;
 pub const stack_trace = @import("utils/stack_trace.zig");
@@ -28,6 +29,13 @@ pub fn init(allocator: Allocator, dsn: ?[]const u8, options: SentryOptions) !*Se
     const global_scope = try scopes.getGlobalScope();
     global_scope.bindClient(client);
     return client;
+}
+
+/// Properly shutdown and cleanup the Sentry client and all associated resources
+pub fn shutdown(allocator: Allocator, client: *SentryClient) void {
+    client.deinit();
+    allocator.destroy(client);
+    scopes.deinitScopeManager();
 }
 
 pub fn captureEvent(event: Event) !?EventId {

--- a/src/scope.zig
+++ b/src/scope.zig
@@ -543,6 +543,26 @@ pub fn initScopeManager(allocator: Allocator) !void {
     g_scope_manager = ScopeManager.init(allocator);
 }
 
+/// Deinitialize the global scope manager and clean up all resources
+pub fn deinitScopeManager() void {
+    if (g_scope_manager) |*manager| {
+        // Clean up global scope
+        global_scope_mutex.lock();
+        defer global_scope_mutex.unlock();
+
+        if (global_scope) |scope| {
+            scope.deinit();
+            manager.allocator.destroy(scope);
+            global_scope = null;
+        }
+
+        // Note: Thread-local scopes should be cleaned up by their respective threads
+        // before calling this function. We can't safely clean them up here.
+
+        g_scope_manager = null;
+    }
+}
+
 pub fn getAllocator() !Allocator {
     if (g_scope_manager) |*manager| {
         return manager.allocator;

--- a/src/types/SentryOptions.zig
+++ b/src/types/SentryOptions.zig
@@ -38,7 +38,7 @@ pub const SentryOptions = struct {
     }
 
     pub fn deinit(self: *@This()) void {
-        if (self.dsn) |dsn| dsn.deinit();
+        if (self.dsn) |*dsn| dsn.deinit();
 
         if (self.allocator) |allocator| if (self.environment) |environment| allocator.free(environment);
         if (self.allocator) |allocator| if (self.release) |release| allocator.free(release);

--- a/src/types/User.zig
+++ b/src/types/User.zig
@@ -37,12 +37,14 @@ pub const User = struct {
         };
     }
 
-    pub fn deinit(self: *const @This()) void {
-        if (self.allocator) |allocator| if (self.id) |id| allocator.free(id);
-        if (self.allocator) |allocator| if (self.username) |username| allocator.free(username);
-        if (self.allocator) |allocator| if (self.email) |email| allocator.free(email);
-        if (self.allocator) |allocator| if (self.name) |name| allocator.free(name);
-        if (self.allocator) |allocator| if (self.ip_address) |ip| allocator.free(ip);
+    pub fn deinit(self: *@This()) void {
+        if (self.allocator) |allocator| {
+            if (self.id) |id| allocator.free(id);
+            if (self.username) |username| allocator.free(username);
+            if (self.email) |email| allocator.free(email);
+            if (self.name) |name| allocator.free(name);
+            if (self.ip_address) |ip| allocator.free(ip);
+        }
     }
 
     pub fn jsonStringify(self: @This(), jw: anytype) !void {
@@ -92,17 +94,18 @@ test "User - clone functionality" {
 
     // Create original user
     var original = User{
+        .allocator = allocator,
         .id = try allocator.dupe(u8, "123"),
         .username = try allocator.dupe(u8, "testuser"),
         .email = try allocator.dupe(u8, "test@example.com"),
         .name = try allocator.dupe(u8, "Test User"),
         .ip_address = try allocator.dupe(u8, "192.168.1.1"),
     };
-    defer original.deinit(allocator);
+    defer original.deinit();
 
     // Clone the user
     var cloned = try original.clone(allocator);
-    defer cloned.deinit(allocator);
+    defer cloned.deinit();
 
     // Verify all fields were cloned
     try testing.expectEqualStrings("123", cloned.id.?);
@@ -123,17 +126,18 @@ test "User - clone with null fields" {
 
     // Create user with some null fields
     var original = User{
+        .allocator = allocator,
         .id = try allocator.dupe(u8, "456"),
         .username = null,
         .email = try allocator.dupe(u8, "partial@example.com"),
         .name = null,
         .ip_address = null,
     };
-    defer original.deinit(allocator);
+    defer original.deinit();
 
     // Clone the user
     var cloned = try original.clone(allocator);
-    defer cloned.deinit(allocator);
+    defer cloned.deinit();
 
     // Verify fields were cloned correctly
     try testing.expectEqualStrings("456", cloned.id.?);

--- a/src/utils/test_utils.zig
+++ b/src/utils/test_utils.zig
@@ -23,7 +23,7 @@ pub fn createFullTestEvent(allocator: std.mem.Allocator) !Event {
     fingerprint[0] = try allocator.dupe(u8, "custom");
     fingerprint[1] = try allocator.dupe(u8, "fingerprint");
 
-    const user = try User.init(
+    var user = try User.init(
         allocator,
         "123",
         "testuser",


### PR DESCRIPTION
Updates the pattern on structs to include the allocator in the struct so deinit works without parameters. Also adds a cleanup for the scope manager